### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/src/services/ej_service.py
+++ b/src/services/ej_service.py
@@ -493,9 +493,9 @@ class EJService:
                 for file_path in file_paths:
                     try:
                         # Normalize the file path
-                        normalized_path = os.path.normpath(file_path)
+                        candidate_path = os.path.abspath(os.path.join(safe_root, file_path))
                         # Ensure the path is within the safe root directory
-                        if not normalized_path.startswith(safe_root):
+                        if not candidate_path.startswith(os.path.abspath(safe_root)):
                             logging.error(f'File path {file_path} is outside the allowed directory.')
                             return None
                         with open(normalized_path, 'r', encoding='utf-8') as infile:

--- a/src/services/ej_service.py
+++ b/src/services/ej_service.py
@@ -487,11 +487,18 @@ class EJService:
         return transaction_data
 
     def merge_files(self, file_paths, output_path='merged_EJ_logs.txt'):
+        safe_root = '/safe/root/directory'  # Define the safe root directory
         try:
             with open(output_path, 'w', encoding='utf-8') as outfile:
                 for file_path in file_paths:
                     try:
-                        with open(file_path, 'r', encoding='utf-8') as infile:
+                        # Normalize the file path
+                        normalized_path = os.path.normpath(file_path)
+                        # Ensure the path is within the safe root directory
+                        if not normalized_path.startswith(safe_root):
+                            logging.error(f'File path {file_path} is outside the allowed directory.')
+                            return None
+                        with open(normalized_path, 'r', encoding='utf-8') as infile:
                             outfile.write(infile.read())
                             outfile.write('\n')
                     except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/syed-reza98/NetCon_PyVue/security/code-scanning/1](https://github.com/syed-reza98/NetCon_PyVue/security/code-scanning/1)

To fix the issue, we need to validate the `file_paths` parameter to ensure that it does not contain malicious paths. A common approach is to normalize the paths using `os.path.normpath` and verify that they are within a predefined safe directory. This ensures that even if a user provides a path with traversal sequences (`../`), it will not escape the safe directory.

Steps to fix:
1. Define a safe root directory (e.g., `/safe/root/directory`) where all file operations are allowed.
2. Normalize each path in `file_paths` using `os.path.normpath`.
3. Check that the normalized path starts with the safe root directory. If not, raise an exception or log an error.
4. Apply this validation in the `merge_files` method before attempting to open any files.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
