### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/src/controllers/ej_controller.py
+++ b/src/controllers/ej_controller.py
@@ -145,8 +145,8 @@ def load_logs():
 
             return jsonify({"transactions": transactions_json}), 200  # Send only valid transactions
         except Exception as e:
-            print(f"ERROR: {str(e)}")  # Print the error in logs
-            return jsonify({"error": str(e)}), 500
+            logging.error("An error occurred while processing the request", exc_info=True)  # Log the error with stack trace
+            return jsonify({"error": "An internal error occurred"}), 500
     else:
         print("Trial period has expired")
         # "Trial period has expired.", "Please contact Networld Technology Limited to extend your Trial."


### PR DESCRIPTION
Potential fix for [https://github.com/syed-reza98/NetCon_PyVue/security/code-scanning/5](https://github.com/syed-reza98/NetCon_PyVue/security/code-scanning/5)

To fix the issue, we will replace the exposed exception details with a generic error message for the user. The detailed exception information will be logged on the server for debugging purposes. This ensures that sensitive information is not exposed to external users while still allowing developers to diagnose issues.

Steps to implement the fix:
1. Replace the `{"error": str(e)}` response with a generic error message, such as `{"error": "An internal error occurred"}`.
2. Log the detailed exception information (e.g., stack trace) using the `logging` module for internal debugging purposes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
